### PR TITLE
fixed a bug

### DIFF
--- a/hooks/pre_install.lua
+++ b/hooks/pre_install.lua
@@ -6,7 +6,7 @@ local util = require("util")
 --- @return table Version information
 function PLUGIN:PreInstall(ctx)
     if #util.RELEASES == 0 then
-        self:Available(ctx)
+        util:getInfo()
     end
     local releases = util.RELEASES
     for _, release in ipairs(releases) do

--- a/metadata.lua
+++ b/metadata.lua
@@ -5,7 +5,7 @@ PLUGIN = {}
 --- Plugin name
 PLUGIN.name = "bun"
 --- Plugin version
-PLUGIN.version = "0.1.1"
+PLUGIN.version = "0.1.2"
 --- Plugin homepage
 PLUGIN.homepage = "https://github.com/ahai-code/vfox-bun"
 --- Plugin license, please choose a correct license according to your needs.


### PR DESCRIPTION
Before this change, the plugin could not determine available bun versions because the self:Avaliable() function was not getting called, making it impossible to install any version of bun.