### PR TITLE
Get data directly from oven-sh/bun github release page

### DIFF
--- a/lib/github.lua
+++ b/lib/github.lua
@@ -1,0 +1,77 @@
+local github = {}
+
+github.__index = github
+local githubSingleton = setmetatable({}, github)
+githubSingleton.SOURCE_URL = "https://api.github.com/repos/oven-sh/bun/releases"
+githubSingleton.RELEASES ={}
+
+function github:convertFromGH(respInfo)
+    local result = {}
+    for _, release in ipairs(respInfo) do
+        local version = release.tag_name:gsub("bun.v", "")
+        local assets_filtered = filter_assets(release.assets)
+        
+        for _, asset in ipairs(assets_filtered) do
+            local extracted_item = extract_data(asset)
+
+            if result[extracted_item["Os"]] == nil then
+                result[extracted_item["Os"]] = {}
+            end
+
+            if result[extracted_item["Os"]][version] == nil then
+                result[extracted_item["Os"]][version] = {}
+            end
+
+            table.insert(result[extracted_item["Os"]][version], extracted_item)
+        end
+    end
+
+    return result
+end
+
+function filter_assets(assets)
+    local result = assets
+    for i = #result, 1, -1 do
+        asset = result[i]
+        if string.find(asset.name, "-profile") then
+            table.remove(result, i)
+        elseif string.find(asset.name, "-baseline") then
+            table.remove(result, i)
+        elseif string.find(asset.name, "-musl") then
+            table.remove(result, i)
+        elseif string.find(asset.name, "SHASUMS256.txt") then
+            table.remove(result, i)
+        end
+    end
+    return result
+end
+
+function extract_data(item)
+    local result = {}
+    result["Url"] = item["browser_download_url"]
+
+    result["Sum"] = ""
+    result["SumType"] = ""    
+
+    if string.find(item["name"], "windows") then
+        result["Os"] = "windows"
+    elseif string.find(item["name"], "darwin") then
+        result["Os"] = "darwin"
+    elseif string.find(item["name"], "linux") then
+        result["Os"] = "linux"
+    else
+        result["Os"] = "Unknown"
+    end
+    
+    if string.find(item["name"], "x64") then
+        result["Arch"] = "amd64"
+    elseif string.find(item["name"], "aarch64") then
+        result["Arch"] = "arm64"
+    else
+        result["Arch"] = "Unknown"
+    end
+
+    return result
+end
+
+return githubSingleton

--- a/lib/util.lua
+++ b/lib/util.lua
@@ -1,10 +1,11 @@
 local http = require("http")
 local json = require("json")
+local github = require("github")
 local util = {}
 
 util.__index = util
 local utilSingleton = setmetatable({}, util)
-utilSingleton.SOURCE_URL = "https://raw.githubusercontent.com/ahai-code/sdk-sources/main/bun.json"
+utilSingleton.SOURCE_URL = "https://api.github.com/repos/oven-sh/bun/releases"
 utilSingleton.RELEASES ={}
 
 function util:compare_versions(v1o, v2o)
@@ -44,7 +45,9 @@ function util:getInfo()
     if resp.status_code ~= 200 then
         error("Failed to get information: status_code =>" .. resp.status_code)
     end
-    local respInfo = json.decode(resp.body)[RUNTIME.osType]
+    local respInfo = json.decode(resp.body)
+    local fromGH = github:convertFromGH(respInfo)
+    respInfo = fromGH[RUNTIME.osType]
     for version, array in pairs(respInfo) do
         local url = ""
         for _, obj in ipairs(array) do


### PR DESCRIPTION
I added a `github.lua` helper file and made minor changes to the `util.lua` file for  this plugin to be able to get release data directly from [oven-sh/bun releases](https://github.com/oven-sh/bun/releases).

This is my first time writing lua. So, if you need anything changed, please just let me know. 

Thanks for the plugin.